### PR TITLE
added reason for failed tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,8 +75,7 @@ class BrowserstackHelper extends Helper {
      */
     async _failed(test, error) {
         const sessionId = this._getSessionId();
-        await this._updateBuild(sessionId, { 'status': 'failed', 'name': test.title });
-    }
+        await this._updateBuild(sessionId, { 'status': 'failed', 'name': test.title , 'reason' : test.err.message});}
 
     _getSessionId() {
         if (this.helpers['WebDriver']) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "LICENSE"
   ],
   "dependencies": {
+    "chai": "^4.2.0",
     "tinyurl": "^1.1.4"
   }
 }


### PR DESCRIPTION
Hello,
this small update add the reason of failed tests on browserstak ihm. 
instead of (Marked via REST API) now we can have somthing like (Marked via REST API : MESSAGE)
Thanks for this helper, it saved me a lot of time :-)
