### PR TITLE
Fixing "no matching helper" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
-let tinyurl = require("tinyurl");
-const Helper = require("codeceptjs").helper;
+const tinyurl = require("tinyurl");
 
 /**
  * Browserstack Helper for Codeceptjs

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "main": "index.js",
   "devDependencies": {
     "chai": "^4.2.0",
+    "codeceptjs": "^2.3.2",
     "mocha": "^6.0.2",
     "sinon": "^7.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/PeterNgTr/codeceptjs-bshelper#readme",
   "main": "index.js",
   "devDependencies": {
+    "chai": "^4.2.0",
     "mocha": "^6.0.2",
     "sinon": "^7.3.0"
   },
@@ -32,9 +33,10 @@
     "readme.md",
     "LICENSE"
   ],
+  "peerDependencies": {
+    "codeceptjs": "^2.3.2"
+  },
   "dependencies": {
-    "chai": "^4.2.0",
-    "codeceptjs": "^2.3.2",
     "tinyurl": "^1.1.4"
   }
 }

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -1,5 +1,9 @@
 const sinon = require("sinon");
 const expect = require("chai").expect;
+
+// Required to avoid class undefined errors when initializing our helper
+global.Helper = require("codeceptjs").helper;
+
 const BrowserstackHelper = require("../index.js");
 
 describe("#_getSessionId", () => {
@@ -15,7 +19,7 @@ describe("#_getSessionId", () => {
         expect(bsHelper._getSessionId()).to.be.equal("WebDriver");
         stub.restore();
     });
-    
+
     it("should get sessionId of Appium", () => {
         stub = sinon.stub(bsHelper, "_getSessionId").callsFake(() => "Appium");
         expect(bsHelper._getSessionId()).to.be.equal("Appium");
@@ -39,7 +43,7 @@ describe("#_getSessionId", () => {
 
 describe("#_shortenUrl", () => {
     let bsHelper;
-    
+
     beforeEach(() => {
         bsHelper = new BrowserstackHelper();
     });


### PR DESCRIPTION
When trying out this helper myself, I got an error `No matching helper found. Supported helpers: WebDriver/Appium/WebDriverIO`. Looking into this, it appears that the way the class `Helper` is defined doesn't match what CodeceptJS recommends, so not all configuration was getting passed thru.

To fix this but keep tests passing, I declare the `Helper` global before requiring the helper in this package, [just like what CodeceptJS does](https://github.com/Codeception/CodeceptJS/blob/master/lib/codecept.js#L70).

I also changed the `codeceptjs` line in `dependencies` to `peerDependencies` since that is a better use case for this where the package is not the one installing the dependency. `chai` was moved to `devDependencies` since it was only used in the test.

With all these changes, I am now able to use the helper without issue.